### PR TITLE
split commiting forecast update from evaluation

### DIFF
--- a/jobs/europe-covid-forecast/crowd.sh
+++ b/jobs/europe-covid-forecast/crowd.sh
@@ -12,11 +12,14 @@ docker exec -w /home/rstudio/europe-covid-forecast forecast bash crowd-rt-foreca
 # update crowd forecast
 docker exec -w /home/rstudio/europe-covid-forecast forecast Rscript crowd-forecast/update.R
 
+# update github with new forecast
+docker exec -w /home/rstudio/europe-covid-forecast forecast  bash -c "git add -A ; git commit -m 'automated crowd update' ; git pull -Xours; git push"
+
 # update evaluations
 docker exec -w /home/rstudio/europe-covid-forecast forecast bash reports/update.sh
 
 # update evaluation website
 docker exec -w /home/rstudio/europe-covid-forecast forecast bash reports/update-website.sh
 
-# update github with new forecast
-docker exec -w /home/rstudio/europe-covid-forecast forecast  bash -c "git add -A ; git commit -m 'automated crowd update' ; git pull -Xours; git push"
+# update github with evaluation
+docker exec -w /home/rstudio/europe-covid-forecast forecast  bash -c "git add -A ; git commit -m 'automated evaluation update' ; git pull -Xours; git push"


### PR DESCRIPTION
This commits the forecasts before it starts running the evaluation update. That way I can check the forecasts are there before everything has finished. 
Need to update the evaluation at some time, but I'll leave that to future Nikos